### PR TITLE
Fix(android): Apply navigation bar color with edge-to-edge

### DIFF
--- a/android/src/main/java/com/squareetlabs/capacitor/navigationbar/NavigationBarPlugin.java
+++ b/android/src/main/java/com/squareetlabs/capacitor/navigationbar/NavigationBarPlugin.java
@@ -125,9 +125,7 @@ public class NavigationBarPlugin extends Plugin {
             windowInsetsController.setAppearanceLightNavigationBars(darkButtons);
 
             this.currentColor = Color.parseColor(color);
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R || !this.isTransparent) {
-                window.setNavigationBarColor(this.currentColor);
-            }
+            window.setNavigationBarColor(this.currentColor);
 
             String newColor = String.format("#%08X", (this.currentColor));
             newColor = newColor.replace("#FF", "#");


### PR DESCRIPTION
The `setColor` method in `NavigationBarPlugin.java` did not apply the color if the edge-to-edge plugin had set the navigation bar to transparent.

This change removes the conditional check, ensuring the color is always set, and restoring the expected behavior.